### PR TITLE
feat(commitlint): remove custom line length rule

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,9 +1,0 @@
-export default {
-  extends: ['@commitlint/config-conventional'],
-  /*
-   * Any rules defined here will override rules from @commitlint/config-conventional
-   */
-  rules: {
-    'body-max-line-length': [2, 'always', 200],
-  },
-};


### PR DESCRIPTION
Eliminate the custom body max line length rule from the 
commitlint configuration to simplify the setup. This change 
aligns with standard practices and avoids potential 
inconsistency in commit message formatting.